### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.4")
 Then in your build sbt, set the version of scapegoat you wish to use eg:
 
 ```scala
-scapegoatVersion := "1.1.0"
+scapegoatVersion in ThisBuild := "1.1.0"
 ```
 
 That's it! You can now generate the scapegoat reports using the `scapegoat`


### PR DESCRIPTION
There are wrong instructions about how to use it in the `build.sbt` file. It needs `in ThisBuild` when you specify the version of `scapegoat` you want to use.